### PR TITLE
Fix ordering of untrack messages

### DIFF
--- a/xelis_wallet/src/main.rs
+++ b/xelis_wallet/src/main.rs
@@ -981,9 +981,9 @@ async fn untrack_asset(manager: &CommandManager, mut args: ArgumentManager) -> R
     if asset == XELIS_ASSET {
         manager.message("XELIS asset cannot be untracked");
     } else if wallet.untrack_asset(asset).await.context("Error while untracking asset")? {
-        manager.message("Asset ID is not marked as tracked!");
-    } else {
         manager.message("Asset ID is not tracked anymore");
+    } else {
+        manager.message("Asset ID is not marked as tracked!");
     }
 
     Ok(())


### PR DESCRIPTION
## Description

Fixed the message ordering when using `untrack_asset`.

## Type of change

Please select the right one.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Which part is impacted ?

  - [ ] Daemon
  - [x] Wallet
  - [ ] Miner
  - [ ] Misc (documentation, comments, text...)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings